### PR TITLE
Add admin invite code generation

### DIFF
--- a/src/app/api/admin/invite-codes/route.ts
+++ b/src/app/api/admin/invite-codes/route.ts
@@ -1,0 +1,43 @@
+import type { NextRequest } from "next/server";
+import { auth } from "@/lib/auth";
+import { corsPreflightResponse, jsonResponse } from "@/lib/cors";
+import { createInviteCode, serializeInviteCode } from "@/lib/invites";
+
+export async function OPTIONS() {
+  return corsPreflightResponse();
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await auth.api.getSession({ headers: request.headers });
+
+    if (!session) {
+      return jsonResponse({ error: "Authentication required" }, 401);
+    }
+
+    const { success: canCreateInvite } = await auth.api.userHasPermission({
+      body: {
+        userId: session.user.id,
+        permissions: {
+          invite: ["create"],
+        },
+      },
+    });
+
+    if (!canCreateInvite) {
+      return jsonResponse({ error: "Admin access required" }, 403);
+    }
+
+    const inviteCode = await createInviteCode(session.user.id);
+
+    return jsonResponse(
+      {
+        inviteCode: serializeInviteCode(inviteCode),
+      },
+      201,
+    );
+  } catch (error) {
+    console.error("Error generating invite codes:", error);
+    return jsonResponse({ error: "Failed to generate invite codes" }, 500);
+  }
+}

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,7 +1,16 @@
 import { adminClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
+import { ac, adminRole, userRole } from "@/lib/auth-permissions";
 
 // Client side authentication client for the browser
 export const authClient = createAuthClient({
-  plugins: [adminClient()],
+  plugins: [
+    adminClient({
+      ac,
+      roles: {
+        admin: adminRole,
+        user: userRole,
+      },
+    }),
+  ],
 });

--- a/src/lib/auth-permissions.ts
+++ b/src/lib/auth-permissions.ts
@@ -1,0 +1,23 @@
+import { createAccessControl } from "better-auth/plugins/access";
+import {
+  adminAc,
+  defaultStatements,
+  userAc,
+} from "better-auth/plugins/admin/access";
+
+const statement = {
+  ...defaultStatements,
+  invite: ["create"],
+} as const;
+
+export const ac = createAccessControl(statement);
+
+export const adminRole = ac.newRole({
+  ...adminAc.statements,
+  invite: ["create"],
+});
+
+export const userRole = ac.newRole({
+  ...userAc.statements,
+  invite: [],
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,6 +3,7 @@ import { betterAuth } from "better-auth";
 import { mongodbAdapter } from "better-auth/adapters/mongodb";
 import { nextCookies } from "better-auth/next-js";
 import { admin } from "better-auth/plugins";
+import { ac, adminRole, userRole } from "@/lib/auth-permissions";
 import mongoClient from "@/lib/db";
 
 // Server side Better Auth instance
@@ -23,7 +24,13 @@ export const auth = betterAuth({
   ],
   plugins: [
     expo(),
-    admin(),
+    admin({
+      ac,
+      roles: {
+        admin: adminRole,
+        user: userRole,
+      },
+    }),
     nextCookies(), // must be last
   ],
   experimental: {

--- a/src/lib/invites.ts
+++ b/src/lib/invites.ts
@@ -1,0 +1,73 @@
+import { randomBytes } from "node:crypto";
+import type { Document } from "mongodb";
+import { ObjectId } from "mongodb";
+import mongoClient from "@/lib/db";
+
+const INVITE_CODE_TTL_MS = 24 * 60 * 60 * 1000;
+
+export interface InviteCodeDocument {
+  _id: ObjectId;
+  code: string;
+  createdByUserId: string;
+  createdAt: Date;
+  expiresAt: Date;
+  usedAt?: Date | null;
+  usedByUserId?: string | null;
+}
+
+export type InviteCodeResponse = {
+  id: string;
+  code: string;
+  createdAt: string;
+  expiresAt: string;
+};
+
+export const inviteCodesCollection = mongoClient
+  .db()
+  .collection<InviteCodeDocument & Document>("inviteCodes");
+
+// Ensure indexes exist once per process (HMR-safe)
+const globalWithInviteIndexes = globalThis as typeof globalThis &
+  Record<"kaitai.inviteCodes.indexes", boolean | undefined>;
+
+if (!globalWithInviteIndexes["kaitai.inviteCodes.indexes"]) {
+  globalWithInviteIndexes["kaitai.inviteCodes.indexes"] = true;
+  void inviteCodesCollection.createIndex({ code: 1 }, { unique: true });
+  void inviteCodesCollection.createIndex(
+    { expiresAt: 1 },
+    { expireAfterSeconds: 0 },
+  );
+}
+
+function generateInviteCode() {
+  return randomBytes(18).toString("base64url");
+}
+
+export function serializeInviteCode(
+  inviteCode: InviteCodeDocument,
+): InviteCodeResponse {
+  return {
+    id: inviteCode._id.toHexString(),
+    code: inviteCode.code,
+    createdAt: inviteCode.createdAt.toISOString(),
+    expiresAt: inviteCode.expiresAt.toISOString(),
+  };
+}
+
+export async function createInviteCode(
+  createdByUserId: string,
+): Promise<InviteCodeDocument> {
+  const now = new Date();
+  const inviteCode: InviteCodeDocument = {
+    _id: new ObjectId(),
+    code: generateInviteCode(),
+    createdByUserId,
+    createdAt: now,
+    expiresAt: new Date(now.getTime() + INVITE_CODE_TTL_MS),
+    usedAt: null,
+    usedByUserId: null,
+  };
+
+  await inviteCodesCollection.insertOne(inviteCode);
+  return inviteCode;
+}


### PR DESCRIPTION
Add an admin-only API endpoint for generating beta invite codes so account creation can be gated behind short-lived codes.

The new POST /api/admin/invite-codes route requires an authenticated session and checks Better Auth permissions for invite.create before creating a code. Better Auth admin access control is extended with a custom invite.create permission and shared between the server and client auth configuration.

Invite codes are stored in the MongoDB inviteCodes collection with a random base64url code, creator user id, created timestamp, and expiresAt timestamp set to 24 hours after creation. The collection creates a unique index on code and a TTL index on expiresAt, guarded by a global process flag to avoid repeatedly creating indexes during hot reload.

Testing/validation: TypeScript passed and Biome passed for changed files per local validation. Full test suite status is unknown.