### PR TITLE
Gate admin UI on adminPanel permission instead of role string

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,11 +8,27 @@ export default async function Header() {
   const session = await auth.api.getSession({
     headers: await headers(),
   });
+
+  // Gate the admin UI on the server so it honors both role-based admins and
+  // adminUserIds, which only the server-side permission engine can resolve.
+  let canAccessAdmin = false;
+  if (session) {
+    const { success } = await auth.api.userHasPermission({
+      body: {
+        userId: session.user.id,
+        permissions: {
+          adminPanel: ["access"],
+        },
+      },
+    });
+    canAccessAdmin = success;
+  }
+
   return (
     <header className="border-b border-border bg-background relative z-10">
       <div className="container mx-auto px-4 h-14 flex items-center justify-end gap-2">
         {session ? (
-          <UserMenu user={session.user} />
+          <UserMenu user={session.user} canAccessAdmin={canAccessAdmin} />
         ) : (
           <nav className="flex items-center gap-2">
             <SignInDialog />

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -5,11 +5,10 @@ import { type ReactNode, useEffect, useState } from "react";
 import AdminSettingsPage from "@/components/settings/AdminSettingsPage";
 import ModelsSettingsPage from "@/components/settings/ModelsSettingsPage";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { isAdminUser, type SessionUser } from "@/lib/user-utils";
 
 interface SettingsModalProps {
   isOpen: boolean;
-  user: SessionUser;
+  canAccessAdmin: boolean;
   onClose: () => void;
 }
 
@@ -34,20 +33,19 @@ const SETTINGS_SECTIONS: Array<{
 
 export default function SettingsModal({
   isOpen,
-  user,
+  canAccessAdmin,
   onClose,
 }: SettingsModalProps) {
   const [activeSection, setActiveSection] = useState<SettingsSection>("models");
-  const isAdmin = isAdminUser(user);
 
   useEffect(() => {
-    if (!isAdmin && activeSection === "admin") {
+    if (!canAccessAdmin && activeSection === "admin") {
       setActiveSection("models");
     }
-  }, [activeSection, isAdmin]);
+  }, [activeSection, canAccessAdmin]);
 
   const visibleSections = SETTINGS_SECTIONS.filter(
-    (section) => section.id !== "admin" || isAdmin,
+    (section) => section.id !== "admin" || canAccessAdmin,
   );
   const sectionContent: Record<SettingsSection, ReactNode> = {
     models: <ModelsSettingsPage isOpen={isOpen} onClose={onClose} />,

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -17,9 +17,10 @@ import type { SessionUser } from "@/lib/user-utils";
 
 interface UserMenuProps {
   user: SessionUser;
+  canAccessAdmin: boolean;
 }
 
-export default function UserMenu({ user }: UserMenuProps) {
+export default function UserMenu({ user, canAccessAdmin }: UserMenuProps) {
   const router = useRouter();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
@@ -91,7 +92,7 @@ export default function UserMenu({ user }: UserMenuProps) {
             />
             <SettingsModal
               isOpen={isSettingsOpen}
-              user={user}
+              canAccessAdmin={canAccessAdmin}
               onClose={() => setIsSettingsOpen(false)}
             />
           </>,

--- a/src/lib/auth-permissions.ts
+++ b/src/lib/auth-permissions.ts
@@ -7,8 +7,6 @@ import {
 
 const statement = {
   ...defaultStatements,
-  // Stable gate for "can enter the admin area", decoupled from any feature so
-  // that removing a feature (e.g. invites) never affects panel visibility.
   adminPanel: ["access"],
   invite: ["create"],
 } as const;

--- a/src/lib/auth-permissions.ts
+++ b/src/lib/auth-permissions.ts
@@ -7,6 +7,9 @@ import {
 
 const statement = {
   ...defaultStatements,
+  // Stable gate for "can enter the admin area", decoupled from any feature so
+  // that removing a feature (e.g. invites) never affects panel visibility.
+  adminPanel: ["access"],
   invite: ["create"],
 } as const;
 
@@ -14,10 +17,12 @@ export const ac = createAccessControl(statement);
 
 export const adminRole = ac.newRole({
   ...adminAc.statements,
+  adminPanel: ["access"],
   invite: ["create"],
 });
 
 export const userRole = ac.newRole({
   ...userAc.statements,
+  adminPanel: [],
   invite: [],
 });

--- a/src/lib/user-utils.ts
+++ b/src/lib/user-utils.ts
@@ -1,13 +1,4 @@
 export type SessionUser = {
   name: string;
   email: string;
-  role?: string | null;
 };
-
-export function isAdminUser(
-  user: Pick<SessionUser, "role"> | null | undefined,
-) {
-  return (
-    user?.role?.split(",").some((role) => role.trim() === "admin") ?? false
-  );
-}


### PR DESCRIPTION
## Summary
The web client gated the admin Settings section by string-matching `admin` in the session user's role, which diverged from the server's real authorization. This replaces that check with a dedicated, server-resolved `adminPanel:access` permission so the UI agrees with the backend — including for Better Auth `adminUserIds` admins, who previously could call admin APIs but never saw the admin UI.

## Screenshots/Recordings
N/A — no visual change for existing role-based admins; affects which users the admin tab renders for.

## Changes
- **`src/lib/auth-permissions.ts`**: Add an `adminPanel: ["access"]` statement as a stable admin-area entry gate, granted to `adminRole` and withheld from `userRole`. Intentionally decoupled from feature permissions (e.g. `invite:create`) so removing a feature never affects panel visibility.
- **`src/components/Header.tsx`**: Resolve `canAccessAdmin` server-side via `auth.api.userHasPermission({ permissions: { adminPanel: ["access"] } })` and pass it to `UserMenu`. Running through the server permission engine is what makes it honor `adminUserIds`.
- **`src/components/UserMenu.tsx`**: Accept and forward `canAccessAdmin`; stop passing `user` to the modal.
- **`src/components/SettingsModal.tsx`**: Gate the admin tab and redirect-guard on the `canAccessAdmin` prop instead of computing `isAdminUser(user)`.
- **`src/lib/user-utils.ts`**: Remove the now-unused `isAdminUser` helper and the `role` field on `SessionUser`.
- Feature actions are unchanged: `POST /api/admin/invite-codes` still checks its own `invite:create` permission.

## Testing
- `npx tsc --noEmit` — passed, no errors.
- `npx biome check` on all 5 changed files — passed, no fixes.
- Manual (local podman stack): created `admin@kaitai.local` with `role: "admin"`, confirmed the account resolves `adminPanel:access` and the admin Settings tab renders; the invite-codes route remains reachable.