### PR TITLE
Seed default admin for developer testing

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -15,3 +15,9 @@ XAI_API_KEY=your_xai_api_key_here
 OPENROUTER_API_KEY=your_openrouter_api_key_here
 CEREBRAS_API_KEY=your_cerebras_api_key_here
 FIREWORKS_API_KEY=your_fireworks_api_key_here
+
+# Dev-only admin seed (created automatically when NODE_ENV=development)
+# Defaults: admin@localhost.dev / dev-admin-password
+# DEV_ADMIN_EMAIL=admin@localhost.dev
+# DEV_ADMIN_PASSWORD=dev-admin-password
+# DEV_ADMIN_NAME=Dev Admin

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ Copy `.env.local.example` — set `MONGODB_URI` and at least one AI key:
 | `OPENROUTER_API_KEY` | [openrouter.ai](https://openrouter.ai/keys) |
 | `CEREBRAS_API_KEY` | [cloud.cerebras.ai](https://cloud.cerebras.ai/) |
 | `FIREWORKS_API_KEY` | [fireworks.ai](https://fireworks.ai/) |
+| `DEV_ADMIN_EMAIL` | Dev-only; default `admin@localhost.dev` |
+| `DEV_ADMIN_PASSWORD` | Dev-only; default `dev-admin-password` |
+
+### Developer admin account
+
+In development (`NODE_ENV=development`), the app seeds a default admin on startup if it does not already exist:
+
+- **Email:** `admin@localhost.dev`
+- **Password:** `dev-admin-password`
+
+Override with `DEV_ADMIN_EMAIL` / `DEV_ADMIN_PASSWORD` / `DEV_ADMIN_NAME`. This account is never created in production.
 
 ## Development
 

--- a/common/api.ts
+++ b/common/api.ts
@@ -1,4 +1,9 @@
-import type { ImageAnalysisResponse, SentenceAnalysis } from "./types";
+import type {
+  CreateInviteCodeResponse,
+  ImageAnalysisResponse,
+  InviteCode,
+  SentenceAnalysis,
+} from "./types";
 
 export class ApiError extends Error {
   constructor(
@@ -64,4 +69,25 @@ export async function analyzeImage(
   }
 
   return data as ImageAnalysisResponse;
+}
+
+/** Generate a temporary invite code for a permitted administrator. */
+export async function createInviteCode(url: string): Promise<InviteCode> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new ApiError(
+      data.error || "Failed to generate an invite code",
+      response.status,
+    );
+  }
+
+  return (data as CreateInviteCodeResponse).inviteCode;
 }

--- a/common/types.ts
+++ b/common/types.ts
@@ -31,6 +31,17 @@ export interface ImageAnalysisResponse {
   analysis: SentenceAnalysis;
 }
 
+export interface InviteCode {
+  id: string;
+  code: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface CreateInviteCodeResponse {
+  inviteCode: InviteCode;
+}
+
 // Provider types
 export type Provider =
   | "anthropic"

--- a/src/components/settings/AdminSettingsPage.tsx
+++ b/src/components/settings/AdminSettingsPage.tsx
@@ -1,18 +1,161 @@
 "use client";
 
+import { createInviteCode } from "@common/api";
+import type { InviteCode } from "@common/types";
+import { Check, Copy, KeyRound, LoaderCircle, Plus } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+function formatExpiration(expiresAt: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(expiresAt));
+}
+
 export default function AdminSettingsPage() {
+  const [inviteCodes, setInviteCodes] = useState<InviteCode[]>([]);
+  const [copiedInviteId, setCopiedInviteId] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleGenerateInvite = async () => {
+    setIsGenerating(true);
+    setError(null);
+    setCopiedInviteId(null);
+
+    try {
+      const inviteCode = await createInviteCode("/api/admin/invite-codes");
+      setInviteCodes((currentCodes) => [inviteCode, ...currentCodes]);
+    } catch (generateError) {
+      setError(
+        generateError instanceof Error
+          ? generateError.message
+          : "Failed to generate an invite code",
+      );
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const handleCopyInvite = async (inviteCode: InviteCode) => {
+    try {
+      await navigator.clipboard.writeText(inviteCode.code);
+      setCopiedInviteId(inviteCode.id);
+      setError(null);
+    } catch {
+      setError("Unable to copy the invite code. Please copy it manually.");
+    }
+  };
+
   return (
     <div className="min-w-0 flex-1 overflow-y-auto p-6">
       <div className="mb-6">
         <h2 className="text-xl font-semibold text-card-foreground">Admin</h2>
         <p className="mt-2 text-sm text-card-foreground/70">
-          Admin-only settings will go here.
+          Manage administrative access and account invitations.
         </p>
       </div>
 
-      <div className="rounded-lg border border-card-foreground/20 bg-card-foreground/5 p-4 text-sm text-card-foreground/70">
-        Placeholder admin setting content.
-      </div>
+      <section
+        className="overflow-hidden rounded-lg border border-card-foreground/20"
+        aria-labelledby="invite-codes-heading"
+      >
+        <div className="flex flex-col gap-4 bg-card-foreground/5 p-5 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <KeyRound className="h-5 w-5" aria-hidden="true" />
+            </div>
+            <div>
+              <h3
+                id="invite-codes-heading"
+                className="font-semibold text-card-foreground"
+              >
+                Invite codes
+              </h3>
+              <p className="mt-1 max-w-lg text-sm text-card-foreground/70">
+                Generate temporary invite codes. Each code expires automatically
+                after 24 hours.
+              </p>
+            </div>
+          </div>
+
+          <Button
+            type="button"
+            onClick={handleGenerateInvite}
+            disabled={isGenerating}
+            className="w-full sm:w-auto"
+          >
+            {isGenerating ? (
+              <LoaderCircle className="animate-spin" aria-hidden="true" />
+            ) : (
+              <Plus aria-hidden="true" />
+            )}
+            {isGenerating ? "Generating..." : "Generate code"}
+          </Button>
+        </div>
+
+        {error && (
+          <div
+            className="border-t border-red-200 bg-red-50 px-5 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300"
+            role="alert"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="border-t border-card-foreground/20 p-5">
+          {inviteCodes.length === 0 ? (
+            <div className="py-8 text-center">
+              <KeyRound
+                className="mx-auto h-8 w-8 text-card-foreground/30"
+                aria-hidden="true"
+              />
+              <p className="mt-3 text-sm font-medium text-card-foreground">
+                No codes generated in this session
+              </p>
+              <p className="mt-1 text-sm text-card-foreground/60">
+                Generate a code to display and copy it here.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3" aria-live="polite">
+              {inviteCodes.map((inviteCode) => {
+                const isCopied = copiedInviteId === inviteCode.id;
+
+                return (
+                  <div
+                    key={inviteCode.id}
+                    className="rounded-lg border border-card-foreground/20 bg-card p-4"
+                  >
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                      <code className="min-w-0 flex-1 break-all rounded-md bg-card-foreground/5 px-3 py-2 font-mono text-sm font-semibold text-card-foreground">
+                        {inviteCode.code}
+                      </code>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => handleCopyInvite(inviteCode)}
+                        aria-label={`Copy invite code ${inviteCode.code}`}
+                      >
+                        {isCopied ? (
+                          <Check aria-hidden="true" />
+                        ) : (
+                          <Copy aria-hidden="true" />
+                        )}
+                        {isCopied ? "Copied" : "Copy"}
+                      </Button>
+                    </div>
+                    <p className="mt-2 text-xs text-card-foreground/60">
+                      Expires {formatExpiration(inviteCode.expiresAt)}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,11 @@
+export async function register() {
+  if (
+    process.env.NEXT_RUNTIME !== "nodejs" ||
+    process.env.NODE_ENV !== "development"
+  ) {
+    return;
+  }
+
+  const { seedDevAdmin } = await import("@/lib/dev-seed");
+  await seedDevAdmin();
+}

--- a/src/lib/dev-seed.ts
+++ b/src/lib/dev-seed.ts
@@ -1,0 +1,51 @@
+import { auth } from "@/lib/auth";
+import mongoClient from "@/lib/db";
+
+/** Default credentials for local developer testing only. Override via env. */
+export const DEV_ADMIN_DEFAULTS = {
+  email: "admin@localhost.dev",
+  password: "dev-admin-password",
+  name: "Dev Admin",
+} as const;
+
+/**
+ * Idempotently creates a development admin account.
+ * No-ops outside NODE_ENV=development and when the account already exists.
+ */
+export async function seedDevAdmin(): Promise<void> {
+  if (process.env.NODE_ENV !== "development") {
+    return;
+  }
+
+  const email = process.env.DEV_ADMIN_EMAIL ?? DEV_ADMIN_DEFAULTS.email;
+  const password =
+    process.env.DEV_ADMIN_PASSWORD ?? DEV_ADMIN_DEFAULTS.password;
+  const name = process.env.DEV_ADMIN_NAME ?? DEV_ADMIN_DEFAULTS.name;
+
+  try {
+    const existing = await mongoClient
+      .db()
+      .collection("user")
+      .findOne({ email });
+    if (existing) {
+      return;
+    }
+
+    await auth.api.createUser({
+      body: {
+        email,
+        password,
+        name,
+        role: "admin",
+      },
+    });
+
+    console.info(`[dev-seed] Created developer admin account: ${email}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/already|exist/i.test(message)) {
+      return;
+    }
+    console.error("[dev-seed] Failed to seed developer admin account:", error);
+  }
+}

--- a/src/lib/invites.ts
+++ b/src/lib/invites.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import type { InviteCode } from "@common/types";
 import type { Document } from "mongodb";
 import { ObjectId } from "mongodb";
 import mongoClient from "@/lib/db";
@@ -14,13 +15,6 @@ export interface InviteCodeDocument {
   usedAt?: Date | null;
   usedByUserId?: string | null;
 }
-
-export type InviteCodeResponse = {
-  id: string;
-  code: string;
-  createdAt: string;
-  expiresAt: string;
-};
 
 export const inviteCodesCollection = mongoClient
   .db()
@@ -45,7 +39,7 @@ function generateInviteCode() {
 
 export function serializeInviteCode(
   inviteCode: InviteCodeDocument,
-): InviteCodeResponse {
+): InviteCode {
   return {
     id: inviteCode._id.toHexString(),
     code: inviteCode.code,


### PR DESCRIPTION
## Summary
- Seeds a development-only admin account on Next.js server startup via `instrumentation.ts`
- Defaults to `admin@localhost.dev` / `dev-admin-password` (overridable via env); never runs in production
- Documents credentials in README and `.env.local.example`

## Test plan
- [ ] `docker compose up` or `npm run dev` and confirm `[dev-seed] Created developer admin account` logs on first start
- [ ] Sign in with `admin@localhost.dev` / `dev-admin-password` and verify admin settings are available
- [ ] Restart the server and confirm seed is idempotent (no duplicate user / no error)
- [ ] Confirm production/`NODE_ENV=production` does not create the account


Made with [Cursor](https://cursor.com)