### PR TITLE
Require an invite code to sign up on web and mobile

### DIFF
--- a/mobile/app/sign-up.tsx
+++ b/mobile/app/sign-up.tsx
@@ -16,11 +16,17 @@ export default function SignUpScreen() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [inviteCode, setInviteCode] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   const handleSignUp = async () => {
-    if (!name.trim() || !email.trim() || !password.trim()) {
+    if (
+      !name.trim() ||
+      !email.trim() ||
+      !password.trim() ||
+      !inviteCode.trim()
+    ) {
       setError("Please fill in all fields.");
       return;
     }
@@ -28,10 +34,14 @@ export default function SignUpScreen() {
     setError(null);
     setIsLoading(true);
 
+    // inviteCode is not in the better-auth client types but is passed through
+    // to the server, where the sign-up hook validates it.
+    const inviteCodeBody = { inviteCode: inviteCode.trim() };
     const { data, error: signUpError } = await authClient.signUp.email({
       name: name.trim(),
       email: email.trim(),
       password,
+      ...inviteCodeBody,
     });
 
     if (signUpError) {
@@ -113,6 +123,26 @@ export default function SignUpScreen() {
               autoComplete="new-password"
               className="p-4 rounded-xl border-2 border-border text-base text-foreground bg-transparent"
             />
+          </View>
+
+          {/* Invite Code */}
+          <View className="mb-5">
+            <ThemedText type="defaultSemiBold" className="mb-2 text-sm">
+              Invite Code
+            </ThemedText>
+            <TextInput
+              value={inviteCode}
+              onChangeText={setInviteCode}
+              placeholder="Your invite code"
+              placeholderTextColor="#9ca3af"
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoComplete="off"
+              className="p-4 rounded-xl border-2 border-border text-base text-foreground bg-transparent"
+            />
+            <ThemedText className="text-xs opacity-70 mt-2">
+              Sign-ups are invite only. Ask an admin for a code.
+            </ThemedText>
           </View>
 
           {/* Error */}

--- a/src/app/analyze/[sentence]/AnalysisContent.tsx
+++ b/src/app/analyze/[sentence]/AnalysisContent.tsx
@@ -20,6 +20,9 @@ export default function AnalysisContent({ sentence }: { sentence: string }) {
     }
   }, []);
 
+  // TODO: Replace the `cancelled` flag with an AbortController threaded
+  // through analyzeSentence so stale requests are actually aborted instead of
+  // just having their results ignored.
   useEffect(() => {
     let cancelled = false;
 

--- a/src/app/api/admin/invite-codes/route.ts
+++ b/src/app/api/admin/invite-codes/route.ts
@@ -7,6 +7,10 @@ export async function OPTIONS() {
   return corsPreflightResponse();
 }
 
+// TODO: Extract the session/permission boilerplate below into withAuth /
+// withPermission higher-order wrappers (e.g. src/lib/api-auth.ts) and adopt
+// them across all API routes, so handlers receive a non-nullable session
+// instead of repeating the getSession + !session checks.
 export async function POST(request: NextRequest) {
   try {
     const session = await auth.api.getSession({ headers: request.headers });

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -26,6 +26,7 @@ export default function SignUpPage() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [inviteCode, setInviteCode] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -34,11 +35,15 @@ export default function SignUpPage() {
     setError(null);
     setIsLoading(true);
 
+    // inviteCode is not in the better-auth client types but is passed through
+    // to the server, where the sign-up hook validates it.
+    const inviteCodeBody = { inviteCode: inviteCode.trim() };
     const { data, error } = await authClient.signUp.email({
       name,
       email,
       password,
       callbackURL: "/", // server side fallback since we already redirect to "/" in the handler
+      ...inviteCodeBody,
     });
 
     if (error) {
@@ -124,6 +129,30 @@ export default function SignUpPage() {
               />
               <FieldDescription>
                 Must be at least 8 characters long.
+              </FieldDescription>
+            </Field>
+
+            <Field>
+              <FieldLabel
+                htmlFor="inviteCode"
+                className="text-sm font-semibold text-foreground"
+              >
+                Invite code
+              </FieldLabel>
+              <Input
+                id="inviteCode"
+                type="text"
+                value={inviteCode}
+                onChange={(e) => setInviteCode(e.target.value)}
+                required
+                autoComplete="off"
+                autoCapitalize="off"
+                spellCheck={false}
+                placeholder="Your invite code"
+                className="px-4 py-3 border-2 border-input rounded-lg bg-background text-foreground placeholder-muted-foreground focus:border-primary focus:ring-0 focus:outline-none transition-colors"
+              />
+              <FieldDescription>
+                Sign-ups are invite only. Ask an admin for a code.
               </FieldDescription>
             </Field>
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,10 +1,29 @@
 import { expo } from "@better-auth/expo";
 import { betterAuth } from "better-auth";
 import { mongodbAdapter } from "better-auth/adapters/mongodb";
+import { APIError, createAuthMiddleware } from "better-auth/api";
 import { nextCookies } from "better-auth/next-js";
 import { admin } from "better-auth/plugins";
 import { ac, adminRole, userRole } from "@/lib/auth-permissions";
 import mongoClient from "@/lib/db";
+import {
+  claimInviteCode,
+  findValidInviteCode,
+  markInviteCodeUsedBy,
+} from "@/lib/invites";
+
+const INVITE_CODE_ERROR = "A valid invite code is required to sign up.";
+
+function inviteCodeFromBody(body: unknown): string | null {
+  if (typeof body !== "object" || body === null) {
+    return null;
+  }
+  const { inviteCode } = body as Record<string, unknown>;
+  if (typeof inviteCode !== "string" || inviteCode.trim() === "") {
+    return null;
+  }
+  return inviteCode.trim();
+}
 
 // Server side Better Auth instance
 export const auth = betterAuth({
@@ -22,6 +41,43 @@ export const auth = betterAuth({
     "kaitai://",
     ...(process.env.NODE_ENV === "development" ? ["exp://", "exp://**"] : []),
   ],
+  hooks: {
+    before: createAuthMiddleware(async (ctx) => {
+      if (ctx.path !== "/sign-up/email") {
+        return;
+      }
+      const inviteCode = inviteCodeFromBody(ctx.body);
+      if (!inviteCode || !(await findValidInviteCode(inviteCode))) {
+        throw new APIError("BAD_REQUEST", { message: INVITE_CODE_ERROR });
+      }
+    }),
+  },
+  databaseHooks: {
+    user: {
+      create: {
+        // Only /sign-up/email carries an invite code; other user-creation
+        // paths (admin createUser, dev seeding) are exempt from the check.
+        before: async (_user, ctx) => {
+          if (ctx?.path !== "/sign-up/email") {
+            return;
+          }
+          const inviteCode = inviteCodeFromBody(ctx.body);
+          if (!inviteCode || !(await claimInviteCode(inviteCode))) {
+            throw new APIError("BAD_REQUEST", { message: INVITE_CODE_ERROR });
+          }
+        },
+        after: async (user, ctx) => {
+          if (ctx?.path !== "/sign-up/email") {
+            return;
+          }
+          const inviteCode = inviteCodeFromBody(ctx.body);
+          if (inviteCode) {
+            await markInviteCodeUsedBy(inviteCode, user.id);
+          }
+        },
+      },
+    },
+  },
   plugins: [
     expo(),
     admin({

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -71,9 +71,16 @@ export const auth = betterAuth({
             return;
           }
           const inviteCode = inviteCodeFromBody(ctx.body);
-          if (inviteCode) {
-            await markInviteCodeUsedBy(inviteCode, user.id);
+          if (!inviteCode) {
+            // Unreachable via normal flows: the before hooks reject sign-ups
+            // without a valid invite code, so getting here means they were
+            // bypassed and user creation was not gated.
+            console.error(
+              `[auth] Sign-up user ${user.id} was created without an invite code in the request body; invite hooks did not run as expected.`,
+            );
+            return;
           }
+          await markInviteCodeUsedBy(inviteCode, user.id);
         },
       },
     },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -41,6 +41,8 @@ export const auth = betterAuth({
     "kaitai://",
     ...(process.env.NODE_ENV === "development" ? ["exp://", "exp://**"] : []),
   ],
+  // The invite gate below is scoped to /sign-up/email, so any new public
+  // signup surface added later (e.g. social login) must be gated separately.
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
       if (ctx.path !== "/sign-up/email") {

--- a/src/lib/invites.ts
+++ b/src/lib/invites.ts
@@ -48,6 +48,38 @@ export function serializeInviteCode(
   };
 }
 
+export async function findValidInviteCode(
+  code: string,
+): Promise<InviteCodeDocument | null> {
+  return inviteCodesCollection.findOne({
+    code,
+    usedAt: null,
+    expiresAt: { $gt: new Date() },
+  });
+}
+
+/**
+ * Atomically marks an unused, unexpired invite code as used. Returns false if
+ * the code is invalid or was already claimed (e.g. by a concurrent sign-up).
+ */
+export async function claimInviteCode(code: string): Promise<boolean> {
+  const claimed = await inviteCodesCollection.findOneAndUpdate(
+    { code, usedAt: null, expiresAt: { $gt: new Date() } },
+    { $set: { usedAt: new Date() } },
+  );
+  return claimed !== null;
+}
+
+export async function markInviteCodeUsedBy(
+  code: string,
+  userId: string,
+): Promise<void> {
+  await inviteCodesCollection.updateOne(
+    { code },
+    { $set: { usedByUserId: userId } },
+  );
+}
+
 export async function createInviteCode(
   createdByUserId: string,
 ): Promise<InviteCodeDocument> {


### PR DESCRIPTION
## Summary
Makes sign-up invite only on both the web and Expo mobile clients. Enforcement lives server-side in Better Auth hooks, so the invite requirement cannot be bypassed by calling the API directly.

## Screenshots/Recordings
N/A

## Changes
- **Server** (`src/lib/auth.ts`, `src/lib/invites.ts`)
  - `before` hook on `/sign-up/email` rejects requests whose `inviteCode` is missing, expired, or already used, with one generic error message so responses don't reveal whether a code exists.
  - `user.create.before` database hook atomically claims the code (`findOneAndUpdate`), so concurrent sign-ups can't double-spend a code; `user.create.after` records `usedByUserId`. Hooks are scoped to `/sign-up/email`, so admin `createUser` and dev seeding are unaffected, and the duplicate-email check runs before the claim so failed sign-ups don't burn codes.
  - New invite helpers: `findValidInviteCode`, `claimInviteCode`, `markInviteCodeUsedBy`.
- **Web** (`src/app/sign-up/page.tsx`) and **mobile** (`mobile/app/sign-up.tsx`): required "Invite code" field; the code is passed through `authClient.signUp.email` as an extra body field.
- TODO comments for two follow-ups spotted along the way: AbortController-based cancellation in `AnalysisContent`, and `withAuth`/`withPermission` wrappers to replace per-route session boilerplate.

## Testing
- E2E against a local compose Mongo + `next dev`:
  - Sign-up with no invite code → 400
  - Sign-up with a bogus code → 400
  - Admin sign-in → generate code via `/api/admin/invite-codes` → sign-up with it → 200, account created
  - Reusing the consumed code → 400; Mongo doc shows `usedAt` and `usedByUserId` set to the new user
- `npx tsc --noEmit` clean on both apps (only pre-existing, unrelated errors remain) and `biome check` passes on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)